### PR TITLE
Travis: Use current user inside docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,8 @@ before_script:
   - docker build -t worker $TRAVIS_BUILD_DIR/.ci
 
 script:
-  - docker run -w /workspace -v $TRAVIS_BUILD_DIR:/workspace worker .ci/$CI_TARGET.sh
+  - docker run
+    -u "$(id -u):$(id -g)"
+    -w /workspace
+    -v $TRAVIS_BUILD_DIR:/workspace
+    worker .ci/$CI_TARGET.sh


### PR DESCRIPTION
Avoids problems with root-owned files in the workspace after building inside Docker.