### PR TITLE
Bugfix: Fixed missing include of std::function in test/mock_server.h

### DIFF
--- a/test/mock_server.h
+++ b/test/mock_server.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <functional>
 
 #include <franka/robot_state.h>
 #include <research_interface/gripper/types.h>


### PR DESCRIPTION
make of master branch thows an error of missing function std::function using:
cmake 3.9.3
gcc 7.2.0
GNU Make 4.2.1

Including functional in test/mock_server.h resolvest this while passing all tests.