### PR TITLE
Fix twist calculation in rate_limiting_tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.8.1 - UNRELEASED
+
+Requires Panda system version >= 4.0.0
+
+### Changed
+
+ * Bug fixes in `rate_limitng_tests.cpp`.
+
 ## 0.8.0 - 2020-04-29
 
 Requires Panda system version >= 4.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 project(libfranka
-  VERSION 0.8.0
+  VERSION 0.8.1
   LANGUAGES CXX
 )
 


### PR DESCRIPTION
The calculation of the twist was wrong.
The delta rotation (R_dot) was always zero due to a typo.
I also fixed the equation to: S(w)  = R_dot * R' 
from slide 9 from https://www.diag.uniroma1.it/~deluca/rob1_en/11_DifferentialKinematics.pdf