### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Requires Panda system version >= 4.0.0
 
 ## 0.7.1 - 2019-07-08
 
-Requires Panda system version >= 3.0.0
+Requires Panda system version 3.X
 
 ### Changed
 
@@ -23,7 +23,7 @@ Requires Panda system version >= 3.0.0
 
 ## 0.7.0 - 2019-07-05
 
-Requires Panda system version >= 3.0.0
+Requires Panda system version 3.X
 
 ### Added
 
@@ -47,7 +47,7 @@ Requires Panda system version >= 3.0.0
 
 ## 0.6.0 - 2019-02-06
 
-Requires Panda system version >= 3.0.0
+Requires Panda system version 3.X
 
  * Added support for Ubuntu 18.04 (Bionic).
  * **EXPERIMENTAL** Added support for Windows.
@@ -57,7 +57,7 @@ Requires Panda system version >= 3.0.0
 
 ## 0.5.0 - 2018-08-08
 
-Requires Panda system version >= 1.3.0
+Requires Panda system version 1.3.X or 2.1.X
 
 ### Motion and control interfaces
 
@@ -76,7 +76,7 @@ Requires Panda system version >= 1.3.0
 
 ## 0.4.0 - 2018-06-21
 
-Requires Panda system version >= 1.3.0
+Requires Panda system version 1.3.X or 2.1.X
 
 ### Motion and control interfaces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.8.0 - UNRELEASED
+## 0.8.0 - 2020-04-29
 
 Requires Panda system version >= 4.0.0
 
@@ -10,13 +10,6 @@ Requires Panda system version >= 4.0.0
    defaults to the identity transformation.
  * Add `F_T_NE` and `NE_T_EE` to `franka::RobotState`.
  * Add support for the cobot pump with `franka::VacuumGripper`.
-
-## 0.7.2 - UNRELEASED
-
-Requires Panda system version >= 3.0.0
-
-### Changed
-
  * CPack: Add conflict with `ros-melodic-libfranka`.
  * Fix missing include for Windows (#55).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 project(libfranka
-  VERSION 0.7.2
+  VERSION 0.8.0
   LANGUAGES CXX
 )
 


### PR DESCRIPTION
Compatibility description was misleading as "requires version >= 3.0.0" implies that it is compatible with 4.X as well.
Compatibility until libfranka 0.3.0 not updated due to missing information.