### PR TITLE
fix some documentation and spelling mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Requires Panda system version >= 4.0.0
 ### Changed
 
  * Minor documentation fixes.
- * Bug fixes in `rate_limitng_tests.cpp`.
+ * Bug fixes in `rate_limiting_tests.cpp`.
 
 ## 0.8.0 - 2020-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Requires Panda system version >= 4.0.0
 
 ### Changed
 
+ * Minor documentation fixes.
  * Bug fixes in `rate_limitng_tests.cpp`.
 
 ## 0.8.0 - 2020-04-29

--- a/examples/examples_common.h
+++ b/examples/examples_common.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * Sets a default collision behavior, joint impedance, Cartesian impedance, and filter frequency.
+ * Sets a default collision behavior, joint impedance and Cartesian impedance.
  *
  * @param[in] robot Robot instance to set behavior on.
  */

--- a/include/franka/exception.h
+++ b/include/franka/exception.h
@@ -80,7 +80,7 @@ struct ControlException : public Exception {
   explicit ControlException(const std::string& what, std::vector<franka::Record> log = {}) noexcept;
 
   /**
-   * Vector of states and commands logged just before the exception occured.
+   * Vector of states and commands logged just before the exception occurred.
    */
   const std::vector<franka::Record> log;
 };

--- a/include/franka/model.h
+++ b/include/franka/model.h
@@ -180,7 +180,7 @@ class Model {
   /**
    * Calculates the 7x7 mass matrix. Unit: \f$[kg \times m^2]\f$.
    *
-   * @param[in] robot_state State from which the pose should be calculated.
+   * @param[in] robot_state State from which the mass matrix should be calculated.
    *
    * @return Vectorized 7x7 mass matrix, column-major.
    */

--- a/include/franka/rate_limiting.h
+++ b/include/franka/rate_limiting.h
@@ -25,7 +25,7 @@ constexpr double kLimitEps = 1e-3;
  */
 constexpr double kNormEps = std::numeric_limits<double>::epsilon();
 /**
- * Number of packets losts considered for the definition of velocity limits.
+ * Number of packets lost considered for the definition of velocity limits.
  * When a packet is lost, FCI assumes a constant acceleration model
  */
 constexpr double kTolNumberPacketsLost = 3.0;
@@ -131,7 +131,7 @@ std::array<double, 7> limitRate(const std::array<double, 7>& max_derivatives,
  * @param[in] max_acceleration Maximum allowed acceleration.
  * @param[in] max_jerk Maximum allowed jerk.
  * @param[in] commanded_velocity Commanded joint velocity of the current time step.
- * @param[in] last_commanded_velocity Commanded joint velocitiy of the previous time step.
+ * @param[in] last_commanded_velocity Commanded joint velocity of the previous time step.
  * @param[in] last_commanded_acceleration Commanded joint acceleration of the previous time step.
  *
  * @throw std::invalid_argument if commanded_velocity is infinite or NaN.
@@ -202,12 +202,12 @@ std::array<double, 7> limitRate(const std::array<double, 7>& max_velocity,
  * FCI filters must be deactivated to work properly.
  *
  * @param[in] max_velocity Per-joint maximum allowed velocity.
- * @param[in] max_acceleration Per-joint maximum allowed velocity.
- * @param[in] max_jerk Per-joint maximum allowed velocity.
- * @param[in] commanded_positions Per-joint maximum allowed acceleration.
- * @param[in] last_commanded_positions Commanded joint positions of the current time step.
- * @param[in] last_commanded_velocities Commanded joint positions of the previous time step.
- * @param[in] last_commanded_accelerations Commanded joint velocities of the previous time step.
+ * @param[in] max_acceleration Per-joint maximum allowed acceleration.
+ * @param[in] max_jerk Per-joint maximum allowed jerk.
+ * @param[in] commanded_positions Commanded joint positions of the current time step.
+ * @param[in] last_commanded_positions Commanded joint positions of the previous time step.
+ * @param[in] last_commanded_velocities Commanded joint velocities of the previous time step.
+ * @param[in] last_commanded_accelerations Commanded joint accelerations of the previous time step.
  *
  * @throw std::invalid_argument if commanded_positions are infinite or NaN.
  *

--- a/include/franka/robot.h
+++ b/include/franka/robot.h
@@ -203,7 +203,7 @@ class Robot {
    * @throw InvalidOperationException if a conflicting operation is already running.
    * @throw NetworkException if the connection is lost, e.g. after a timeout.
    * @throw RealtimeException if realtime priority cannot be set for the current thread.
-   * @throw std::invalid_argument if joint-level torque or joint velocitiy commands are NaN or
+   * @throw std::invalid_argument if joint-level torque or joint velocity commands are NaN or
    * infinity.
    *
    * @see Robot::Robot to change behavior if realtime priority cannot be set.

--- a/include/franka/robot_state.h
+++ b/include/franka/robot_state.h
@@ -234,7 +234,7 @@ struct RobotState {
   std::array<double, 7> dq_d{};
 
   /**
-   * \f$\dot{q}_d\f$
+   * \f$\ddot{q}_d\f$
    * Desired joint acceleration. Unit: \f$[\frac{rad}{s^2}]\f$
    */
   std::array<double, 7> ddq_d{};
@@ -332,7 +332,7 @@ struct RobotState {
 
   /**
    * \f$\dot{\theta}\f$
-   * Motor velocity. Unit: \f$[rad]\f$
+   * Motor velocity. Unit: \f$[\frac{rad}{s}]\f$
    */
   std::array<double, 7> dtheta{};
 

--- a/test/rate_limiting_tests.cpp
+++ b/test/rate_limiting_tests.cpp
@@ -519,7 +519,7 @@ TEST(RateLimiting, CartesianPose) {
       last_cmd_velocity, last_cmd_acceleration, kDeltaT));
 }
 
-TEST(RateLimiting, CartesianPoseIntegrationAndDifferentation) {
+TEST(RateLimiting, CartesianPoseIntegrationAndDifferentiation) {
   std::array<double, 16> last_cmd_pose{
       {0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0}};
   std::array<double, 6> last_cmd_velocity{{1.0, 2.0, 3.0, 0.4, 0.5, 0.3}};


### PR DESCRIPTION
I fixed some documentation issues and spelling mistakes I came across, including the one I introduced myself :see_no_evil: 