### PR TITLE
commandNotPossibleMsg(): improve error message

### DIFF
--- a/include/franka/robot_state.h
+++ b/include/franka/robot_state.h
@@ -413,7 +413,14 @@ struct RobotState {
  */
 std::ostream& operator<<(std::ostream& ostream, const franka::RobotState& robot_state);
 
-/** Streams RobotMode in human-readable form */
-std::ostream& operator<<(std::ostream& ostream, const RobotMode robot_mode);
+/**
+ * Streams RobotMode in human-readable form
+
+ * @param[in] ostream Ostream instance
+ * @param[in] robot_mode RobotMode to stream
+ *
+ * @return Ostream instance
+ */
+std::ostream& operator<<(std::ostream& ostream, RobotMode robot_mode);
 
 }  // namespace franka

--- a/include/franka/robot_state.h
+++ b/include/franka/robot_state.h
@@ -18,7 +18,6 @@ namespace franka {
 /**
  * Describes the robot's current mode.
  */
-
 enum class RobotMode {
   kOther,
   kIdle,

--- a/include/franka/robot_state.h
+++ b/include/franka/robot_state.h
@@ -413,4 +413,7 @@ struct RobotState {
  */
 std::ostream& operator<<(std::ostream& ostream, const franka::RobotState& robot_state);
 
+/** Streams RobotMode in human-readable form */
+std::ostream& operator<<(std::ostream& ostream, const RobotMode robot_mode);
+
 }  // namespace franka

--- a/src/robot_impl.cpp
+++ b/src/robot_impl.cpp
@@ -154,6 +154,7 @@ research_interface::robot::RobotState Robot::Impl::receiveRobotState() {
 }
 
 void Robot::Impl::updateState(const research_interface::robot::RobotState& robot_state) {
+  robot_mode_ = robot_state.robot_mode;
   motion_generator_mode_ = robot_state.motion_generator_mode;
   controller_mode_ = robot_state.controller_mode;
   message_id_ = robot_state.message_id;

--- a/src/robot_impl.h
+++ b/src/robot_impl.h
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <memory>
+#include <sstream>
 #include <type_traits>
 
 #include <franka/model.h>
@@ -57,7 +58,10 @@ class Robot::Impl : public RobotControl {
 
  private:
   std::string commandNotPossibleMsg() const {
-    return " command rejected: command not possible in the current mode!";
+    std::stringstream ss;
+    ss << " command rejected: command not possible in the current mode ("
+       << static_cast<franka::RobotMode>(robot_mode_) << ")!";
+    return ss.str();
   }
 
   template <typename T>
@@ -114,6 +118,7 @@ class Robot::Impl : public RobotControl {
   const RealtimeConfig realtime_config_;  // NOLINT(readability-identifier-naming)
   uint16_t ri_version_;
 
+  research_interface::robot::RobotMode robot_mode_ = research_interface::robot::RobotMode::kOther;
   research_interface::robot::MotionGeneratorMode motion_generator_mode_;
   research_interface::robot::MotionGeneratorMode current_move_motion_generator_mode_ =
       research_interface::robot::MotionGeneratorMode::kIdle;

--- a/src/robot_impl.h
+++ b/src/robot_impl.h
@@ -56,6 +56,10 @@ class Robot::Impl : public RobotControl {
   bool controllerRunning() const noexcept;
 
  private:
+  std::string commandNotPossibleMsg() const {
+    return " command rejected: command not possible in the current mode!";
+  }
+
   template <typename T>
   using IsBaseOfGetterSetter =
       std::is_base_of<research_interface::robot::GetterSetterCommandBase<T, T::kCommand>, T>;
@@ -70,7 +74,7 @@ class Robot::Impl : public RobotControl {
         break;
       case T::Status::kCommandNotPossibleRejected:
         throw CommandException("libfranka: "s + research_interface::robot::CommandTraits<T>::kName +
-                               " command rejected: command not possible in the current mode!");
+                               commandNotPossibleMsg());
       case T::Status::kInvalidArgumentRejected:
         throw CommandException("libfranka: "s + research_interface::robot::CommandTraits<T>::kName +
                                " command rejected: invalid argument!");
@@ -90,7 +94,7 @@ class Robot::Impl : public RobotControl {
         break;
       case T::Status::kCommandNotPossibleRejected:
         throw CommandException("libfranka: "s + research_interface::robot::CommandTraits<T>::kName +
-                               " command rejected: command not possible in the current mode!");
+                               commandNotPossibleMsg());
       default:
         throw ProtocolException("libfranka: Unexpected response while handling "s +
                                 research_interface::robot::CommandTraits<T>::kName + " command!");
@@ -154,7 +158,7 @@ inline void Robot::Impl::handleCommandResponse<research_interface::robot::Move>(
       throw CommandException(
           "libfranka: "s +
           research_interface::robot::CommandTraits<research_interface::robot::Move>::kName +
-          " command rejected: command not possible in the current mode!");
+          commandNotPossibleMsg());
     case research_interface::robot::Move::Status::kStartAtSingularPoseRejected:
       throw CommandException(
           "libfranka: "s +
@@ -195,12 +199,12 @@ inline void Robot::Impl::handleCommandResponse<research_interface::robot::StopMo
       throw CommandException(
           "libfranka: "s +
           research_interface::robot::CommandTraits<research_interface::robot::StopMove>::kName +
-          " command rejected: command not possible in the current mode!");
+          commandNotPossibleMsg());
     case research_interface::robot::StopMove::Status::kAborted:
       throw CommandException(
           "libfranka: "s +
           research_interface::robot::CommandTraits<research_interface::robot::StopMove>::kName +
-          " command rejected: command not possible in the current mode!");
+          commandNotPossibleMsg());
     case research_interface::robot::StopMove::Status::kEmergencyAborted:
       throw CommandException(
           "libfranka: "s +
@@ -241,7 +245,7 @@ inline void Robot::Impl::handleCommandResponse<research_interface::robot::Automa
       throw CommandException("libfranka: "s +
                              research_interface::robot::CommandTraits<
                                  research_interface::robot::AutomaticErrorRecovery>::kName +
-                             " command rejected: command not possible in the current mode!");
+                             commandNotPossibleMsg());
     case research_interface::robot::AutomaticErrorRecovery::Status::
         kManualErrorRecoveryRequiredRejected:
       throw CommandException("libfranka: "s +

--- a/src/robot_impl.h
+++ b/src/robot_impl.h
@@ -61,6 +61,9 @@ class Robot::Impl : public RobotControl {
     std::stringstream ss;
     ss << " command rejected: command not possible in the current mode ("
        << static_cast<franka::RobotMode>(robot_mode_) << ")!";
+    if (robot_mode_ == research_interface::robot::RobotMode::kOther) {
+      ss << " Did you open the brakes?";
+    }
     return ss.str();
   }
 

--- a/src/robot_state.cpp
+++ b/src/robot_state.cpp
@@ -19,6 +19,8 @@ std::ostream& operator<<(std::ostream& ostream, const std::array<T, N>& array) {
   return ostream;
 }
 
+}  // anonymous namespace
+
 std::ostream& operator<<(std::ostream& ostream, const RobotMode robot_mode) {
   ostream << "\"";
   switch (robot_mode) {
@@ -47,8 +49,6 @@ std::ostream& operator<<(std::ostream& ostream, const RobotMode robot_mode) {
   ostream << "\"";
   return ostream;
 }
-
-}  // anonymous namespace
 
 std::ostream& operator<<(std::ostream& ostream, const franka::RobotState& robot_state) {
   ostream << "{\"O_T_EE\": " << robot_state.O_T_EE << ", \"O_T_EE_d\": " << robot_state.O_T_EE_d

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -238,7 +238,7 @@ void testRobotStatesAreEqual(const research_interface::robot::RobotState& expect
   EXPECT_EQ(expected.message_id, actual.time.toMSec());
   EXPECT_EQ(expected.control_command_success_rate, actual.control_command_success_rate);
 
-  franka::RobotMode expected_robot_mode;
+  franka::RobotMode expected_robot_mode = franka::RobotMode::kOther;
   switch (expected.robot_mode) {
     case research_interface::robot::RobotMode::kOther:
       expected_robot_mode = franka::RobotMode::kOther;


### PR DESCRIPTION
Replace multiple occurrences of identical error messages with a function.
Ideally, the current mode would be shown there as well, i.e. 
`command rejected: command not possible in the current mode (reflex)!`

However, I didn't find the corresponding mode member immediately - there are so many similar mode members!