### PR TITLE
add a package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ install(EXPORT FrankaTargets
 # Ignore find_package(Franka) in subprojects.
 set(FRANKA_IS_FOUND TRUE)
 
-option(BUILD_TESTS "Build tests" ON)
+option(BUILD_TESTS "Build tests" OFF)
 if(BUILD_TESTS)
   enable_testing()
   add_subdirectory(test)

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>libfranka</name>
+  <version>0.12.1</version>
+  <description>libfranka is a C++ library for Franka Emika research robots</description>
+  <maintainer email="support@franka.de">Franka Emika GmbH</maintainer>
+  <license>Apache 2.0</license>
+
+  <url type="website">https://frankaemika.github.io</url>
+  <url type="repository">https://github.com/frankaemika/libfranka</url>
+  <url type="bugtracker">https://github.com/frankaemika/libfranka/issues</url>
+  <author>Franka Emika GmbH</author>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <build_depend>libpoco-dev</build_depend>
+  <build_depend>eigen</build_depend>
+
+  <exec_depend>libpoco-dev</exec_depend>
+
+  <doc_depend>doxygen</doc_depend>
+  <doc_depend>graphviz</doc_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This PR adds a `package.xml` file and disables tests by default for a better "build from source" experience.

The `package.xml` has been adapted from https://github.com/frankaemika/libfranka-release/blob/master/foxy/package.xml. I changed `<build_type>ament_cmake</build_type>` from the original file to `<build_type>cmake</build_type>` as the `CMakeLists.txt` is a "pure" CMake project without any ROS 2 (or ament) dependencies.