### PR TITLE
Fix libfmt dependency

### DIFF
--- a/cmake/FrankaConfig.cmake.in
+++ b/cmake/FrankaConfig.cmake.in
@@ -3,6 +3,8 @@ get_filename_component(Franka_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+find_package(fmt REQUIRED)
+
 if(NOT TARGET Franka::Franka)
   include("${Franka_CMAKE_DIR}/FrankaTargets.cmake")
 endif()

--- a/package.xml
+++ b/package.xml
@@ -17,9 +17,11 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <build_depend>eigen</build_depend>
+  <build_depend>fmt</build_depend>
   <build_depend>libpoco-dev</build_depend>
   <build_depend>pinocchio</build_depend>
 
+  <exec_depend>fmt</exec_depend>
   <exec_depend>libpoco-dev</exec_depend>
   <exec_depend>pinocchio</exec_depend>
 


### PR DESCRIPTION
Replaces https://github.com/frankaemika/libfranka/pull/171
- Declare dependency in package.xml (additionally to `CPACK_DEBIAN_PACKAGE_DEPENDS`). This is required for ROS.
  https://github.com/frankaemika/libfranka/blob/fd2951bc76e61d32d835241c40c26562148cd457/CMakeLists.txt#L219
- Transitively forward the dependency to downstream packages.